### PR TITLE
deprecation and pointer to better examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # shiny-docker-demo
 Demonstrates how to wrap a Shiny app for Refinery
 
+**DEPRECATED**: We actually need to use Shiny server in Refinery, because that gives us a graceful fallback when WebSockets is not available.
+Better examples are [our wrapper for Intervene](https://github.com/refinery-platform/intervene-refinery-docker)
+and our [basic Shiny heatmap](https://github.com/refinery-platform/shiny-heatmap-refinery).
+
 ## Development
 With a checkout of the project, and R and Docker installed,
 you should be able to run the same tests locally as are run on Travis:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Demonstrates how to wrap a Shiny app for Refinery
 
 **DEPRECATED**: We actually need to use Shiny server in Refinery, because that gives us a graceful fallback when WebSockets is not available.
-Better examples are [our wrapper for Intervene](https://github.com/refinery-platform/intervene-refinery-docker)
-and our [basic Shiny heatmap](https://github.com/refinery-platform/shiny-heatmap-refinery).
+See [shiny-heatmap-refinery](https://github.com/refinery-platform/shiny-heatmap-refinery) for a very simple example,
+or [intervene-refinery-docker](https://github.com/refinery-platform/intervene-refinery-docker) for an example of porting an existing app.
 
 ## Development
 With a checkout of the project, and R and Docker installed,

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,5 +1,4 @@
-FROM rocker/shiny:latest
-# No other tags available :(
+FROM rocker/shiny:3.5.1
 
 RUN R -e 'install.packages("rjson")'
 

--- a/fixtures/hello.html
+++ b/fixtures/hello.html
@@ -4,7 +4,7 @@
 
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <script type="application/shiny-singletons"></script>
-  <script type="application/html-dependencies">json2[2014.02.04];jquery[1.12.4];shiny[1.0.5];bootstrap[3.3.7]</script>
+  <script type="application/html-dependencies">json2[2014.02.04];jquery[1.12.4];shiny[1.1.0];bootstrap[3.3.7]</script>
 <script src="shared/json2-min.js"></script>
 <script src="shared/jquery.min.js"></script>
 <link href="shared/shiny.css" rel="stylesheet" />


### PR DESCRIPTION
Alternatively, we could just delete the project, but I would like to keep it around... it is so much simpler than what shiny server requires, and it would be nice to get back to something like this.